### PR TITLE
Remove AL2 ami type from usage

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -50,4 +50,7 @@ module "eks-addons" {
     dependency_update = true
     version           = "4.12.2",
   }
+  cluster_autoscaler_helm_config = {
+    version = "9.52.1"
+  }
 }

--- a/k8s.tf
+++ b/k8s.tf
@@ -16,12 +16,14 @@ module "eks" {
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
   managed_node_groups = {
     default = {
-      node_group_name = "default"
-      min_size        = var.linuxNodeCountMin
-      max_size        = var.linuxNodeCountMax
-      desired_size    = var.linuxNodeCountMin
-      subnet_ids      = local.private_subnet_ids
-      instance_types  = var.linuxNodeSize
+      node_group_name    = "default"
+      min_size           = var.linuxNodeCountMin
+      max_size           = var.linuxNodeCountMax
+      desired_size       = var.linuxNodeCountMin
+      subnet_ids         = local.private_subnet_ids
+      instance_types     = var.linuxNodeSize
+      ami_type           = "BOTTLEROCKET_x86_64"
+      launch_template_os = "bottlerocket"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "linuxNodeCountMax" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the EKS cluster."
-  default     = "1.29"
+  default     = "1.34"
 }
 
 variable "vpcCidr" {


### PR DESCRIPTION
- EKS version upgraded
- AL2 node groups replaced with bottlerocket